### PR TITLE
Build and statically link sqlite3 via the amalgamation

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "sqlite"]
+	path = sqlite
+	url = https://github.com/copies/sqlite

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sqlite3-src"
-version = "0.1.0"
+version = "0.2.0"
 license = "Apache-2.0/MIT"
 authors = ["Ivan Ukhov <ivan.ukhov@gmail.com>"]
 description = "The package provides SQLite."
@@ -9,5 +9,9 @@ repository = "https://github.com/stainless-steel/sqlite3-src"
 build = "build.rs"
 links = "sqlite3"
 
+[features]
+bound = []
+
 [build-dependencies]
 pkg-config = "0.3"
+gcc = "0.3"

--- a/build.rs
+++ b/build.rs
@@ -1,9 +1,16 @@
 extern crate pkg_config;
+extern crate gcc;
 
-const NAME: &'static str = "sqlite3";
 
+#[cfg(not(feature = "bound"))]
 fn main() {
+    const NAME: &'static str = "sqlite3";
     if pkg_config::find_library(NAME).is_err() {
-        println!("cargo:rustc-link-lib=dylib={}", NAME);
+        gcc::compile_library("libsqlite3.a", &["sqlite/sqlite3.c"]);
     }
+}
+
+#[cfg(feature = "bound")]
+fn main() {
+    gcc::compile_library("libsqlite3.a", &["sqlite/sqlite3.c"]);
 }


### PR DESCRIPTION
Howdy!

I've been working with the sqlite crate and realized that sqlite wasn't getting linked unless it had been installed which wasn't ideal for my needs. 

This PR adds the latest amalgamation and builds a static archive to link with instead. Has the benefit of working on Windows as well (tested with the MSVC toolchain).

I bumped the minor version of the crate because it seems like a big enough difference.
