### PR TITLE
Update cc create to 1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,5 +16,5 @@ links = "sqlite3"
 bundled = []
 
 [build-dependencies]
-gcc = "0.3"
+cc = "1.0"
 pkg-config = "0.3"

--- a/build.rs
+++ b/build.rs
@@ -1,8 +1,10 @@
-extern crate gcc;
+extern crate cc;
 extern crate pkg_config;
 
 fn main() {
     if cfg!(feature = "bundled") || pkg_config::find_library("sqlite3").is_err() {
-        gcc::compile_library("libsqlite3.a", &["source/sqlite3.c"]);
+        cc::Build::new()
+            .file("source/sqlite3.c")
+            .compile("libsqlite3.a");
     }
 }


### PR DESCRIPTION
The gcc crate has been renamed to cc to make it more generically
applicable. Also, it is now available as a 1.0 release. This change
adjusts the library to use the new version of the cc crate in version
1.0.