### PR TITLE
Added WASM support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    branches:
+      - main
 
 jobs:
   check:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,11 +17,41 @@ jobs:
   test:
     strategy:
       matrix:
-        os: [macos-latest, ubuntu-latest]
+        os: [macos-latest, ubuntu-latest, windows-latest]
+        include:
+          - os: macos-latest
+            wasi_sdk_os: macos
+          - os: ubuntu-latest
+            wasi_sdk_os: linux
+          - os: windows-latest
+            wasi_sdk_os: windows
     runs-on: ${{ matrix.os }}
+    env:
+      WASI_SDK_VERSION: '25'
+      WASI_SDK_NAME: wasi-sdk-25.0-x86_64-${{ matrix.wasi_sdk_os }}
+      WASI_SDK_PATH: ${{ github.workspace }}/wasi-sdk-25.0-x86_64-${{ matrix.wasi_sdk_os }}
     steps:
       - uses: actions/checkout@v4
         with: {submodules: true}
-      - run: rustup toolchain install stable --profile=minimal
+      - name: Install Rust toolchain
+        run: rustup toolchain install stable --profile=minimal
+      - name: Install WASM targets
+        run: rustup target add wasm32-unknown-unknown wasm32-wasip1 wasm32-wasip2
       - run: cargo test
       - run: cargo test --features bundled
+      - name: Download WASI SDK
+        uses: robinraju/release-downloader@v1
+        with:
+          repository: WebAssembly/wasi-sdk
+          fileName: ${{ env.WASI_SDK_NAME }}.tar.gz
+          latest: false
+          tag: wasi-sdk-${{ env.WASI_SDK_VERSION }}
+          extract: true
+      - name: Build for wasm32-unknown-unknown
+        run: cargo build --target wasm32-unknown-unknown --features bundled
+        env:
+          RUSTFLAGS: --cfg=sqlite3_src_wasi_env="p1"
+      - name: Build for wasm32-wasip1
+        run: cargo build --target wasm32-wasip1 --features bundled
+      - name: Build for wasm32-wasip2
+        run: cargo build --target wasm32-wasip2 --features bundled

--- a/README.md
+++ b/README.md
@@ -11,6 +11,18 @@ It is also possible to enable various [compile-time options] by setting
 environment variables with the same names, such as
 `SQLITE_ENABLE_FTS5`.
 
+## WASM support
+This package supports WASM through WASI.
+If you compile for the `wasip1` or `wasip2` targets all you need to do is define either 
+
+* the `sqlite3_src_wasi_sdk_path` configuration flag in rustc, or
+* the `WASI_SDK_PATH` environment variable
+
+to point to an installation of the [WASI SDK].
+
+If you are compiling for `wasm32-unknown-unknown` you also need to set the `sqlite3_src_wasi_env`
+configuration flag in rustc to specify which WASI version you want to compile for (e.g. `p1`).
+
 
 ## Contribution
 
@@ -20,6 +32,7 @@ will be licensed according to the terms given in [LICENSE.md](LICENSE.md).
 
 [SQLite]: https://sqlite.org
 [compile-time options]: https://www.sqlite.org/compile.html
+[WASI SDK]: https://github.com/WebAssembly/wasi-sdk/releases
 
 [build-img]: https://github.com/stainless-steel/sqlite3-src/workflows/build/badge.svg
 [build-url]: https://github.com/stainless-steel/sqlite3-src/actions/workflows/build.yml

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ If you compile for the `wasip1` or `wasip2` targets all you need to do is define
 * the `sqlite3_src_wasi_sdk_path` configuration flag in rustc, or
 * the `WASI_SDK_PATH` environment variable
 
-to point to an installation of the [WASI SDK].
+to point to an installation of the [WASI SDK]. The path must be absolute, but Cargo supports resolving relative paths in the `[env]` section of the `.cargo/config.toml` file.
 
 If you are compiling for `wasm32-unknown-unknown` you also need to set the `sqlite3_src_wasi_env`
 configuration flag in rustc to specify which WASI version you want to compile for (e.g. `p1`).

--- a/build.rs
+++ b/build.rs
@@ -30,6 +30,7 @@ fn main() {
             build.define("SQLITE_OMIT_LOAD_EXTENSION", "1");
             build.define("SQLITE_THREADSAFE", "0");
             build.flag("-Wno-unused");
+            build.flag("-Wno-unused-parameter");
         }
 
         build.compile("libsqlite3.a");

--- a/build.rs
+++ b/build.rs
@@ -1,6 +1,9 @@
-use std::env;
+use std::{env, path::Path};
 
 fn main() {
+    let target_family = env::var("CARGO_CFG_TARGET_FAMILY").unwrap();
+    let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap();
+
     if cfg!(feature = "bundled") || pkg_config::find_library("sqlite3").is_err() {
         let mut build = cc::Build::new();
         build.file("source/sqlite3.c");
@@ -9,6 +12,26 @@ fn main() {
                 build.define(&name, value.as_str());
             }
         }
+
+        if target_family == "wasm" {
+            let wasi_sdk_env = env::var("CARGO_CFG_SQLITE3_SRC_WASI_SDK_PATH")
+                .or(env::var("WASI_SDK_PATH"))
+                .unwrap();
+            let wasi_sdk = Path::new(&wasi_sdk_env).canonicalize().unwrap();
+            build.compiler(wasi_sdk.join("bin/clang"));
+            if target_os != "wasi" {
+                let Ok(wasi_env) = env::var("CARGO_CFG_SQLITE3_SRC_WASI_ENV") else {
+                    println!("cargo::error=Could not detect WASI environment. Please set the sqlite3_src_wasi_env config flag (e.g. \"p1\").");
+                    return;
+                };
+                build.target(&format!("wasm32-wasi{wasi_env}"));
+            }
+            build.define("__wasi__", None);
+            build.define("SQLITE_OMIT_LOAD_EXTENSION", "1");
+            build.define("SQLITE_THREADSAFE", "0");
+            build.flag("-Wno-unused");
+        }
+
         build.compile("libsqlite3.a");
     }
 }


### PR DESCRIPTION
This PR adds WASM support by compiling for `wasip1` or `wasip2` which has been supported in SQLite since version 3.41.0. If you are compiling for the `wasm32-wasip1` or `wasm32-wasip2` targets in rustc, all you need to do is point to an installation of the WASI SDK. If you are compiling for the generic `wasm32-unknown-unknown` target you also need to specify which version of WASI to compile SQLite for.

Closes #4.